### PR TITLE
#22: Updated version to 0.32.0, added stack size

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -26,4 +26,4 @@ jobs:
       - name: Run tests
         run: mvn install -Pjacoco
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v4-beta

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -11,7 +11,7 @@ jobs:
   codecov:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -11,7 +11,7 @@ jobs:
   codecov:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v3
       - name: Set up JDK
         uses: actions/setup-java@v3
         with:

--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,13 @@ SOFTWARE.
   <packaging>jar</packaging>
   <name>eo-json</name>
   <properties>
-    <eolang.version>0.29.6</eolang.version>
+    <eolang.version>0.32.0</eolang.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <!-- This is required for later correct replacement of argLine -->
+    <argLine/>
+    <!-- This is the size of the stack, which you can modify from command line -->
+    <stack-size>256M</stack-size>
   </properties>
   <description>JSON parser for EOLANG</description>
   <url>https://github.com/objectionary/eo-json</url>
@@ -104,6 +108,21 @@ SOFTWARE.
   </dependencies>
   <build>
     <plugins>
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <argLine>
+            @{argLine} -Xss${stack-size}
+          </argLine>
+          <properties>
+            <configurationParameters>
+              junit.jupiter.execution.parallel.enabled = true
+              junit.jupiter.execution.parallel.mode.default = concurrent
+              junit.jupiter.execution.parallel.mode.classes.default = concurrent
+            </configurationParameters>
+          </properties>
+        </configuration>
+      </plugin>
       <plugin>
         <groupId>org.eolang</groupId>
         <artifactId>eo-maven-plugin</artifactId>


### PR DESCRIPTION
Closes #22 
I added `stack-size` because rultor cannot merge it due to stack-overflow.
Codecov was already failed in #9 .

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on updating the `codecov-action` version and adding configuration to the `maven-surefire-plugin`. 

### Detailed summary
- Updated `codecov-action` version from `v4` to `v4-beta`.
- Added configuration to the `maven-surefire-plugin` in `pom.xml`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->